### PR TITLE
[fix] Removed `version` from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # This docker-compose.yml file is intended for development support. It
 # is *not* meant for production.
 
-version: '3'
 name: satosa
 
 services:


### PR DESCRIPTION
It causes a warning saying : docker-compose.yml: `version` is obsolete